### PR TITLE
Create repo code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -13,7 +13,7 @@ This Code of Conduct applies to the following people in `jupyter-a11y-mgmt` repo
 - reviewers
 - contributors
 
-While the `jupyter-a11y-mgmt` repository is our primary space, it may be necesary gather on other platforms to complete our work. The Code of Conduct applies to any online space where we announce we will be gathering to support work on the repository, whether meeting in real time or asynchorously.
+While the `jupyter-a11y-mgmt` repository is our primary space, it may be necessary to gather on other platforms to complete our work. The Code of Conduct applies to any online space where we announce we will be gathering to support work on the repository, whether meeting in real-time or asynchronously.
 
 This includes:
 - Video and text chats
@@ -27,7 +27,7 @@ Examples of unacceptable behavior include:
 - Harassment of any participants in any form
 - Deliberate intimidation, stalking, or following
 - Logging or taking screenshots of online activity for harassment purposes
-- Publishing others’ private information, such as a physical or electronic address, without explicit permission
+- Publishing others’ private information, such as a physical or electronic address, without explicit permission (a.k.a doxing)
 - Violent threats or language directed against another person
 - Incitement of violence or harassment towards any individual, including encouraging a person to commit suicide or to engage in self-harm
 - Creating additional online accounts in order to harass another person or circumvent a ban

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,79 @@
+# jupyter-a11y-mgmt Repository Code of Conduct
+
+The `jupyter-a11y-mgmt` repository is a part of the Project Jupyter community. As such, it follows [Project Jupyter's Code of Conduct](https://jupyter.org/conduct/).
+
+Additionally, our team feels the need to specify our expectations around scope and unacceptable behavior as follows:
+
+## Scope and collaboration spaces
+
+This Code of Conduct applies to the following people in `jupyter-a11y-mgmt` repository:
+- admins of the online space
+- all community members
+- maintainers
+- reviewers
+- contributors
+
+While the `jupyter-a11y-mgmt` repository is our primary space, it may be necesary gather on other platforms to complete our work. The Code of Conduct applies to any online space where we announce we will be gathering to support work on the repository, whether meeting in real time or asynchorously.
+
+This includes:
+- Video and text chats
+- Official communications (like blog posts)
+- Interactions on GitHub whether through issues, pull requests, comments, review, or related
+
+## Inappropriate behavior
+
+Examples of unacceptable behavior include:
+
+- Harassment of any participants in any form
+- Deliberate intimidation, stalking, or following
+- Logging or taking screenshots of online activity for harassment purposes
+- Publishing others’ private information, such as a physical or electronic address, without explicit permission
+- Violent threats or language directed against another person
+- Incitement of violence or harassment towards any individual, including encouraging a person to commit suicide or to engage in self-harm
+- Creating additional online accounts in order to harass another person or circumvent a ban
+- Sexual language and imagery in online communities or in any conference venue, including talks
+- Insults, put downs, or jokes that are based upon stereotypes, that are exclusionary, or that hold others up for ridicule
+- Excessive swearing
+- Unwelcome sexual attention or advances
+- Unwelcome physical contact, including simulated physical contact (eg, textual descriptions like “hug” or “backrub) without consent or after a request to stop
+- Pattern of inappropriate social contact, such as requesting/assuming inappropriate levels of intimacy with others
+- Sustained disruption of online community discussions, in-person presentations, or other in-person events
+- Continued one-on-one communication after requests to cease
+- Other conduct that is inappropriate for a professional audience including people of many different backgrounds
+
+Community members asked to stop any inappropriate behavior are expected to comply immediately.
+
+## During-event consequences
+
+If a participant engages in behavior that violates this Code of Conduct, they are subject to the consequences listed in the Project Jupyter Code of Conduct.
+
+To create a safe environment during any real-time interactions, immediate action on Code of Conduct violations may be needed. Immediate actions may include the following:
+- Warning by moderators
+- Banning from text or video chat
+- Removal from breakout/discussion rooms
+- Removal from the collaboration space
+
+### Procedure For Reporting Incidents
+
+
+For violations that do not require immediate action, you may report directly following the process listed at the [Project Jupyter Code of Conduct](https://jupyter.org/conduct/).
+
+If you believe someone is in physical danger, including from themselves, the most important thing is to get that person help. Please contact the appropriate crisis number, non-emergency number, or police number. You can consult with a moderator to help find an appropriate number.
+
+If you believe someone has violated the Code of Conduct, we encourage you to report it. If you are unsure whether the incident is a violation, or whether the space where it happened is covered by the Code of Conduct, we encourage you to still report it. We are fine with receiving reports where we decide to take no action for the sake of creating a safer space.
+
+Whether for immediate or post-event actions, you may report Code of Conduct violations to at least one of the following moderators:
+- Isabela Presedo-Floyd (ipresedo@quansight.com)
+- Tania Allard (tallard@quansight.com)
+- Other Jupyter community members
+
+As soon as possible, the incident and action will be reported as a Project Jupyter Code of Conduct violation following the process listed [here](https://jupyter.org/conduct/).
+
+## Code of conduct license
+
+All sections of the Code of Conduct created specifically for the event are licensed under the [Creative Commons Attribution-ShareAlike 3.0 Unported License](https://creativecommons.org/licenses/by-sa/3.0/).
+
+## References
+[PyCon US 2021](https://us.pycon.org/2021/about/code-of-conduct/) which in turn draws from many Code of Conduct resources. 
+
+Thank you for helping make this a welcoming, friendly community for everyone.


### PR DESCRIPTION
Fixes #40 

This PR:
-  Adds `CODE_OF_CONDUCT.md` to the repo
- Proposes additions/greater specificity to the foundational [Project Jupyter Code of Conduct](jupyter.org/conduct)

It is also based on the work I did at the [tentative accessibility workshop code of conduct](https://github.com/Quansight-Labs/jupyter-accessibility-workshops/blob/05afb632df575b00de3442ff6849e24c9b35c0fb/code-of-conduct.md).

As usual, feedback is welcome!