### PR TITLE
Add accessibility workshop links to news-media

### DIFF
--- a/docs/news-media/intro.md
+++ b/docs/news-media/intro.md
@@ -4,8 +4,16 @@
 
 * [EOSS Summit  meeting 2021 - Project presentation](https://figshare.com/articles/presentation/INCLUSIVE_AND_ACCESSIBLE_SCIENTIFIC_COMPUTING_IN_THE_JUPYTER_ECOSYSTEM/16913428)
 
-### Blogs
+## Blogs
 
 * [EOSS CZI grant announcement](https://labs.quansight.org/blog/2021/08/czi-eoss4-grants-at-quansight-labs/) - Quansight Labs blog
 * [CZI awards three EOSS grants to Jupyter community members](https://blog.jupyter.org/czi-awards-three-eoss-grants-to-jupyter-community-members-6aef43bd9468) - Jupyter Blog
 * [JupyterLab Accessibility posts in the Quansight Labs Blog](https://labs.quansight.org/categories/jlaba11y/) - by Isabela Presedo-Floyd
+
+## Jupyter accessibility workshops
+
+A series of [Jupyter community workshops](https://blog.jupyter.org/jupyter-community-workshops-cbd34ac82549) 
+in January and March 2022 focused on learning and practicing foundational 
+accessibility skills.
+
+All event resources, from workshop recordings to slides to notes, can be found on the [Jupyter accessibility workshop planning repo](https://github.com/Quansight-Labs/jupyter-accessibility-workshops#readme).


### PR DESCRIPTION
Fixes #93 

This PR adds a description and links for the Jupyter accessibility workshops earlier this year. Please let me know if you think the content needs fixing or belongs elsewhere.

Thanks! 🌻 